### PR TITLE
Fix the incorrect command in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # Script to setup environment
 sudo apt update
-sudo apt -y cmake install make git clang++-7 libgmp-dev g++ parallel
+sudo apt install -y cmake make git clang++-7 libgmp-dev g++ parallel
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-7 1000


### PR DESCRIPTION
It appears that there is likely a typo in
```
sudo apt -y cmake install make git clang++-7 libgmp-dev g++ parallel
```
which causes the installation to fail on Ubuntu.

In addition, beyond this PR, it seems that Ubuntu would like clang-7 instead of clang++-7.